### PR TITLE
do not escape single quotes

### DIFF
--- a/syntaxes/c-al.tmLanguage.json
+++ b/syntaxes/c-al.tmLanguage.json
@@ -85,11 +85,7 @@
         "strings": {
             "name": "string.quoted.single.c-al",
             "begin": "'",
-            "end": "'",
-            "patterns": [{
-                "name": "constant.character.escape.c-al",
-                "match": "\\\\."
-            }]
+            "end": "'"
         },
         "language_variables": {
             "match": "\\b(CurrPage|CurrReport|Rec|RequestOptionsPage|xRec)\\b",


### PR DESCRIPTION
Hey,

I had problems when a string contains a backslash. The backslash escapes the following single quote and the highlighting is broken after that.

I hope the attached pictures explaining it a bit better.

![before](https://user-images.githubusercontent.com/15175001/27499711-5a9a2d5a-5865-11e7-99ac-bdff3570464f.png)

![after](https://user-images.githubusercontent.com/15175001/27499712-5a9aeec0-5865-11e7-882b-3de943e3528d.png)
